### PR TITLE
[RFC] swiftmailer support

### DIFF
--- a/lib/Stampie/Integration/SwiftMailerTransport.php
+++ b/lib/Stampie/Integration/SwiftMailerTransport.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Stampie\Integration;
+
+use Stampie\MailerInterface;
+use Stampie\Message;
+
+/**
+ * A SwiftMailer Transport class for Stampie.
+ *
+ * @author Andreas Hucks <andreas.hucks@duochrome.net>
+ */
+class SwiftMailerTransport implements \Swift_Transport
+{
+    /**
+     * @var Stampie\MailerInterface
+     */
+    private $stampie;
+
+    /**
+     * @var Swift_Events_EventDispatcher
+     */
+    private $dispatcher;
+
+    public function __construct(MailerInterface $stampie, \Swift_Events_EventDispatcher $dispatcher)
+    {
+        $this->stampie = $stampie;
+        $this->dispatcher = $dispatcher;
+    }
+
+    /**
+     * Not used.
+     *
+     * @return boolean
+     */
+    public function isStarted()
+    {
+        return false;
+    }
+
+    /**
+     * Not used.
+     */
+    public function start() {}
+
+    /**
+     * Not used.
+     */
+    public function stop() {}
+
+    /**
+     * Send the given Message.
+     *
+     * Recipient/sender data will be retrieved from the Message API.
+     * The return value is the number of recipients who were accepted for delivery.
+     *
+     * @param Swift_Mime_Message $message
+     * @param string[] &$failedRecipients to collect failures by-reference
+     * @return int
+     */
+    public function send(\Swift_Mime_Message $message, &$failedRecipients = null)
+    {
+        $failedRecipients = (array)$failedRecipients;
+
+        if ($event = $this->dispatcher->createSendEvent($this, $message)) {
+            $this->dispatcher->dispatchEvent($event, 'beforeSendPerformed');
+            if ($event->bubbleCancelled()) {
+                return 0;
+            }
+        }
+
+        $count =
+            count((array)$message->getTo()) + count((array)$message->getCc()) + count((array)$message->getBcc());
+
+        // TODO: convert possible exceptions to \Swift_TransportException?
+        $success = $this->stampie->send($this->getStampieMessage($message));
+
+        if ($event) {
+            $event->setResult($success ? \Swift_Events_SendEvent::RESULT_SUCCESS : \Swift_Events_SendEvent::RESULT_FAILED);
+            $this->dispatcher->dispatchEvent($event, 'sendPerformed');
+        }
+
+        return $success ? $count : 0;
+    }
+
+    /**
+     * Register a plugin in the Transport.
+     *
+     * @param Swift_Events_EventListener $plugin
+     */
+    public function registerPlugin(\Swift_Events_EventListener $plugin)
+    {
+        $this->dispatcher->bindEventListener($plugin);
+    }
+
+    /**
+     * @param \Swift_Mime_Message $message
+     * @return \Stampie\MessageInterface
+     */
+    protected function getStampieMessage(\Swift_Mime_Message $message)
+    {
+        // solution?
+    }
+
+}


### PR DESCRIPTION
Hi,

I'd like to hear your opinion about adding a Swift_Transport implementation to Stampie as per this PR (not complete yet, see below). This would allow Stampie to be used as a drop-in package for every project already using SwiftMailer.

If the idea is basically fine with you, I'd like to discuss the implementation of Stampie\Integration\SwiftMailerTransport::getStampieMessage(). This method is needed as long as the \Swift_Mime_Message implementation in question does not also implement Stampie\MessageInterface (not likely if we want to use the Transport transparently in other projects).

To be able to convert between the messages, getStampieMessage() will require a version of Stampie\MessageInterface with the setters defined as well.

I'm not quite clear why you left out the from and subject fields/accessors from Stampie\Message, otherwise this could be used as well for conversion?

Cheers
