### PR TITLE
Simplified the MailerInterface

### DIFF
--- a/lib/Stampie/Mailer.php
+++ b/lib/Stampie/Mailer.php
@@ -3,6 +3,7 @@
 namespace Stampie;
 
 use Stampie\Adapter\AdapterInterface;
+use Stampie\Adapter\ResponseInterface;
 
 /**
  * Minimal implementation of a MailerInterface
@@ -23,7 +24,7 @@ abstract class Mailer implements MailerInterface
 
     /**
      * @param AdapterInterface $adapter
-     * @param string $serverToken
+     * @param string           $serverToken
      */
     public function __construct(AdapterInterface $adapter, $serverToken)
     {
@@ -88,10 +89,40 @@ abstract class Mailer implements MailerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Return a key -> value array of headers
+     *
+     * example:
+     *     array('X-Header-Name' => 'value')
+     *
+     * @return array
      */
-    public function getHeaders()
+    protected function getHeaders()
     {
         return array();
     }
+
+    /**
+     * @return string
+     */
+    abstract protected function getEndpoint();
+
+    /**
+     * Return a a string formatted for the correct Mailer endpoint.
+     * Postmark this is Json, SendGrid it is a urlencoded parameter list
+     *
+     * @param MessageInterface $message
+     *
+     * @return string
+     */
+    abstract protected function format(MessageInterface $message);
+
+    /**
+     * If a Response is not successful it will be passed to this method
+     * each Mailer should then throw an HttpException with an optional
+     * ApiException to help identify the problem.
+     *
+     * @throws \Stampie\Exception\ApiException
+     * @throws \Stampie\Exception\HttpException
+     */
+    abstract protected function handle(ResponseInterface $response);
 }

--- a/lib/Stampie/Mailer/MailChimpSts.php
+++ b/lib/Stampie/Mailer/MailChimpSts.php
@@ -21,7 +21,7 @@ class MailChimpSts extends Mailer
      * Splits the ServerToken up and uses the last part as the <dc>. More information
      * is at http://apidocs.mailchimp.com/sts/rtfm/
      */
-    public function getEndpoint()
+    protected function getEndpoint()
     {
         return strtr('http://<dc>.sts.mailchimp.com/1.0/SendEmail.json', array(
             '<dc>' => current(array_reverse(explode('-', $this->getServerToken())))
@@ -31,7 +31,7 @@ class MailChimpSts extends Mailer
     /**
      * {@inheritdoc}
      */
-    public function format(MessageInterface $message)
+    protected function format(MessageInterface $message)
     {
         $parameters = array(
             'apikey'  => $this->getServerToken(),
@@ -52,7 +52,7 @@ class MailChimpSts extends Mailer
      *
      * "You can consider any non-200 HTTP response code an error - the returned data will contain more detailed information"
      */
-    public function handle(ResponseInterface $response)
+    protected function handle(ResponseInterface $response)
     {
         $httpException = new HttpException($response->getStatusCode(), $response->getStatusText());
         $error         = json_decode($response->getContent());

--- a/lib/Stampie/Mailer/MailGun.php
+++ b/lib/Stampie/Mailer/MailGun.php
@@ -14,7 +14,7 @@ class MailGun extends \Stampie\Mailer
     /**
      * {@inheritdoc}
      */
-    public function getEndpoint()
+    protected function getEndpoint()
     {
         list($domain,) = explode(':', $this->getServerToken());
 
@@ -37,7 +37,7 @@ class MailGun extends \Stampie\Mailer
     /**
      * {@inheritdoc}
      */
-    public function getHeaders()
+    protected function getHeaders()
     {
         list(, $serverToken) = explode(':', $this->getServerToken());
 
@@ -49,7 +49,7 @@ class MailGun extends \Stampie\Mailer
     /**
      * {@inheritdoc}
      */
-    public function format(MessageInterface $message)
+    protected function format(MessageInterface $message)
     {
         // Custom headers should be prefixed with h:X-My-Header
         $headers = $message->getHeaders();
@@ -73,7 +73,7 @@ class MailGun extends \Stampie\Mailer
     /**
      * {@inheritdoc}
      */
-    public function handle(ResponseInterface $response)
+    protected function handle(ResponseInterface $response)
     {
         throw new HttpException($response->getStatusCode(), $response->getStatusText());
     }

--- a/lib/Stampie/Mailer/Mandrill.php
+++ b/lib/Stampie/Mailer/Mandrill.php
@@ -18,7 +18,7 @@ class Mandrill extends Mailer
     /**
      * {@inheritdoc}
      */
-    public function getEndpoint()
+    protected function getEndpoint()
     {
         return 'https://mandrillapp.com/api/1.0/messages/send.json';
     }
@@ -26,7 +26,7 @@ class Mandrill extends Mailer
     /**
      * {@inheritdoc}
      */
-    public function getHeaders()
+    protected function getHeaders()
     {
         return array(
             'Content-Type' => 'application/json',
@@ -36,7 +36,7 @@ class Mandrill extends Mailer
     /**
      * {@inheritdoc}
      */
-    public function format(MessageInterface $message)
+    protected function format(MessageInterface $message)
     {
         $headers = array_filter(array_merge(
             $message->getHeaders(),
@@ -62,7 +62,7 @@ class Mandrill extends Mailer
      *
      * "You can consider any non-200 HTTP response code an error - the returned data will contain more detailed information"
      */
-    public function handle(ResponseInterface $response)
+    protected function handle(ResponseInterface $response)
     {
         $httpException = new HttpException($response->getStatusCode(), $response->getStatusText());
         $error         = json_decode($response->getContent());

--- a/lib/Stampie/Mailer/PeytzMail.php
+++ b/lib/Stampie/Mailer/PeytzMail.php
@@ -15,7 +15,7 @@ class PeytzMail extends \Stampie\Mailer
     /**
      * {@inheritdoc}
      */
-    public function getEndpoint()
+    protected function getEndpoint()
     {
         return strtr('https://<customer>.peytzmail.com/api/v1/trigger_mails.json', array(
             '<customer>' => current(explode(':', $this->getServerToken())),
@@ -27,7 +27,7 @@ class PeytzMail extends \Stampie\Mailer
      */
     public function setServerToken($serverToken)
     {
-        if (false == strpos($serverToken, ':')) { 
+        if (false == strpos($serverToken, ':')) {
             throw new \InvalidArgumentException('PeytzMail uses a "customer:key" based ServerToken.');
         }
 
@@ -37,7 +37,7 @@ class PeytzMail extends \Stampie\Mailer
     /**
      * {@inheritdoc}
      */
-    public function getHeaders()
+    protected function getHeaders()
     {
         list(, $serverToken) = explode(':', $this->getServerToken());
 
@@ -54,7 +54,7 @@ class PeytzMail extends \Stampie\Mailer
     public function send(MessageInterface $message)
     {
         if (false == $message instanceof TaggableInterface) {
-            throw new \InvalidArgumentException('PeytzMail can only send messages which implement "TaggableMessage".');
+            throw new \InvalidArgumentException('PeytzMail can only send messages which implement "TaggableInterface".');
         }
 
         parent::send($message);
@@ -63,7 +63,7 @@ class PeytzMail extends \Stampie\Mailer
     /**
      * {@inheritdoc}
      */
-    public function format(MessageInterface $message)
+    protected function format(MessageInterface $message)
     {
         $parameters = array(
             'email' => $message->getTo(),
@@ -84,7 +84,7 @@ class PeytzMail extends \Stampie\Mailer
     /**
      * {@inheritdoc}
      */
-    public function handle(ResponseInterface $response)
+    protected function handle(ResponseInterface $response)
     {
         throw new HttpException($response->getStatusCode(), $response->getStatusText());
     }

--- a/lib/Stampie/Mailer/Postmark.php
+++ b/lib/Stampie/Mailer/Postmark.php
@@ -18,7 +18,7 @@ class Postmark extends Mailer
     /**
      * {@inheritdoc}
      */
-    public function getEndpoint()
+    protected function getEndpoint()
     {
         return 'http://api.postmarkapp.com/email';
     }
@@ -26,7 +26,7 @@ class Postmark extends Mailer
     /**
      * {@inheritdoc}
      */
-    public function handle(ResponseInterface $response)
+    protected function handle(ResponseInterface $response)
     {
         $httpException = new HttpException($response->getStatusCode(), $response->getStatusText());
 
@@ -42,7 +42,7 @@ class Postmark extends Mailer
     /**
      * {@inheritdoc}
      */
-    public function getHeaders()
+    protected function getHeaders()
     {
         return array(
             'Content-Type' => 'application/json',
@@ -54,7 +54,7 @@ class Postmark extends Mailer
     /**
      * {@inheritdoc}
      */
-    public function format(MessageInterface $message)
+    protected function format(MessageInterface $message)
     {
         $parameters = array_filter(array(
             'From'     => $message->getFrom(),

--- a/lib/Stampie/Mailer/SendGrid.php
+++ b/lib/Stampie/Mailer/SendGrid.php
@@ -18,7 +18,7 @@ class SendGrid extends Mailer
     /**
      * {@inheritdoc}
      */
-    public function getEndpoint()
+    protected function getEndpoint()
     {
         return 'https://sendgrid.com/api/mail.send.json';
     }
@@ -39,7 +39,7 @@ class SendGrid extends Mailer
     /**
      * {@inheritdoc}
      */
-    public function handle(ResponseInterface $response)
+    protected function handle(ResponseInterface $response)
     {
         $httpException = new HttpException($response->getStatusCode(), $response->getStatusText());
 
@@ -55,7 +55,7 @@ class SendGrid extends Mailer
     /**
      * {@inheritdoc}
      */
-    public function format(MessageInterface $message)
+    protected function format(MessageInterface $message)
     {
         // We should split up the ServerToken on : to get username and password
         list($username, $password) = explode(':', $this->getServerToken());

--- a/lib/Stampie/MailerInterface.php
+++ b/lib/Stampie/MailerInterface.php
@@ -33,41 +33,6 @@ interface MailerInterface
     function getServerToken();
 
     /**
-     * @return string
-     */
-    function getEndpoint();
-
-    /**
-     * Return a key -> value array of headers
-     *
-     * example:
-     *     array('X-Header-Name' => 'value')
-     *
-     * @return array
-     */
-    function getHeaders();
-
-    /**
-     * Return a a string formatted for the correct Mailer endpoint.
-     * Postmark this is Json, SendGrid it is a urlencoded parameter list
-     *
-     * @param MessageInterface $message
-     *
-     * @return string
-     */
-    function format(MessageInterface $message);
-
-    /**
-     * If a Response is not successful it will be passed to this method
-     * each Mailer should then throw an HttpException with an optional
-     * ApiException to help identify the problem.
-     *
-     * @throws \Stampie\Exception\ApiException
-     * @throws \Stampie\Exception\HttpException
-     */
-    function handle(ResponseInterface $response);
-
-    /**
      * @param MessageInterface $message
      *
      * @return Boolean

--- a/tests/Stampie/Tests/GitHub/Issue4Test.php
+++ b/tests/Stampie/Tests/GitHub/Issue4Test.php
@@ -3,7 +3,9 @@
 namespace Stampie\Tests\GitHub;
 
 use Stampie\Adapter\Response;
-use Stampie\Mailer\Postmark;
+use Stampie\Tests\Mailer\TestPostmark;
+
+require_once __DIR__.'/../Mailer/PostmarkTest.php';
 
 /**
  * @author Henrik Bjornskov <henrik@bjrnskov.dk>
@@ -13,7 +15,7 @@ class Issue4Test extends \PHPUnit_Framework_TestCase
     public function testMissingErrorMessageInResponse()
     {
         $response = new Response(422, '{}');
-        $mailer = new Postmark($this->getMock('Stampie\Adapter\AdapterInterface'), 'ServerToken');
+        $mailer = new TestPostmark($this->getMock('Stampie\Adapter\AdapterInterface'), 'ServerToken');
 
         $this->setExpectedException('Stampie\Exception\ApiException', 'Unprocessable Entity');
 

--- a/tests/Stampie/Tests/Mailer/MailChimpStsTest.php
+++ b/tests/Stampie/Tests/Mailer/MailChimpStsTest.php
@@ -5,6 +5,8 @@ namespace Stampie\Tests\Mailer;
 use Stampie\Tests\BaseMailerTest;
 use Stampie\Mailer\MailChimpSts;
 use Stampie\Adapter\Response;
+use Stampie\Adapter\ResponseInterface;
+use Stampie\MessageInterface;
 
 class MailChimpStsTest extends BaseMailerTest
 {
@@ -14,7 +16,7 @@ class MailChimpStsTest extends BaseMailerTest
     {
         parent::setUp();
 
-        $this->mailer = new MailChimpSts(
+        $this->mailer = new TestMailChimpSts(
             $this->adapter,
             self::SERVER_TOKEN
         );
@@ -86,5 +88,23 @@ class MailChimpStsTest extends BaseMailerTest
             array(401, 'Unauthorized'),
             array(504, 'Gateway Timeout'),
         );
+    }
+}
+
+class TestMailChimpSts extends MailChimpSts
+{
+    public function getEndpoint()
+    {
+        return parent::getEndpoint();
+    }
+
+    public function format(MessageInterface $message)
+    {
+        return parent::format($message);
+    }
+
+    public function handle(ResponseInterface $response)
+    {
+        parent::handle($response);
     }
 }

--- a/tests/Stampie/Tests/Mailer/MailGunTest.php
+++ b/tests/Stampie/Tests/Mailer/MailGunTest.php
@@ -14,11 +14,11 @@ class MailGunTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->adapter = $this->createMockAdapter();
-        $this->mailer = new MailGun($this->adapter, self::SERVER_TOKEN);
+        $this->mailer = new TestMailGun($this->adapter, self::SERVER_TOKEN);
     }
 
     /**
-     * @expectedException InvalidArgumentException 
+     * @expectedException InvalidArgumentException
      */
     public function testServerTokenMissingDelimeter()
     {
@@ -45,5 +45,18 @@ class MailGunTest extends \PHPUnit_Framework_TestCase
     protected function createMockAdapter()
     {
         return $this->getMock('Stampie\Adapter\AdapterInterface');
+    }
+}
+
+class TestMailGun extends MailGun
+{
+    public function getEndpoint()
+    {
+        return parent::getEndpoint();
+    }
+
+    public function getHeaders()
+    {
+        return parent::getHeaders();
     }
 }

--- a/tests/Stampie/Tests/Mailer/MandrillTest.php
+++ b/tests/Stampie/Tests/Mailer/MandrillTest.php
@@ -4,6 +4,8 @@ namespace Stampie\Tests\Mailer;
 
 use Stampie\Mailer\Mandrill;
 use Stampie\Adapter\Response;
+use Stampie\Adapter\ResponseInterface;
+use Stampie\MessageInterface;
 
 class MandrillTest extends \Stampie\Tests\BaseMailerTest
 {
@@ -13,7 +15,7 @@ class MandrillTest extends \Stampie\Tests\BaseMailerTest
     {
         parent::setUp();
 
-        $this->mailer = new Mandrill(
+        $this->mailer = new TestMandrill(
             $this->adapter,
             self::SERVER_TOKEN
         );
@@ -77,5 +79,28 @@ class MandrillTest extends \Stampie\Tests\BaseMailerTest
             array(401, 'Unauthorized'),
             array(504, 'Gateway Timeout'),
         );
+    }
+}
+
+class TestMandrill extends Mandrill
+{
+    public function getEndpoint()
+    {
+        return parent::getEndpoint();
+    }
+
+    public function getHeaders()
+    {
+        return parent::getHeaders();
+    }
+
+    public function format(MessageInterface $message)
+    {
+        return parent::format($message);
+    }
+
+    public function handle(ResponseInterface $response)
+    {
+        parent::handle($response);
     }
 }

--- a/tests/Stampie/Tests/Mailer/PeytzMailTest.php
+++ b/tests/Stampie/Tests/Mailer/PeytzMailTest.php
@@ -4,6 +4,8 @@ namespace Stampie\Tests\Mailer;
 
 use Stampie\Mailer\PeytzMail;
 use Stampie\Adapter\Response;
+use Stampie\Adapter\ResponseInterface;
+use Stampie\MessageInterface;
 
 abstract class TaggableMessage implements \Stampie\MessageInterface, \Stampie\Message\TaggableInterface
 {
@@ -17,7 +19,7 @@ class PeytzMailTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->adapter = $this->getMock('Stampie\Adapter\AdapterInterface');
-        $this->mailer = new PeytzMail($this->adapter, 'something:something');
+        $this->mailer = new TestPeytzMail($this->adapter, 'something:something');
     }
 
     public function testSendThrowsExceptionWithInvalidMessageImplementation()
@@ -82,5 +84,28 @@ class PeytzMailTest extends \PHPUnit_Framework_TestCase
         $response = new Response(401, 'Unauthorized');
 
         $this->mailer->handle($response);
+    }
+}
+
+class TestPeytzMail extends PeytzMail
+{
+    public function getEndpoint()
+    {
+        return parent::getEndpoint();
+    }
+
+    public function getHeaders()
+    {
+        return parent::getHeaders();
+    }
+
+    public function format(MessageInterface $message)
+    {
+        return parent::format($message);
+    }
+
+    public function handle(ResponseInterface $response)
+    {
+        parent::handle($response);
     }
 }

--- a/tests/Stampie/Tests/Mailer/PostmarkTest.php
+++ b/tests/Stampie/Tests/Mailer/PostmarkTest.php
@@ -4,6 +4,8 @@ namespace Stampie\Tests\Mailer;
 
 use Stampie\Mailer\Postmark;
 use Stampie\Adapter\Response;
+use Stampie\Adapter\ResponseInterface;
+use Stampie\MessageInterface;
 
 class PostmarkTest extends \Stampie\Tests\BaseMailerTest
 {
@@ -13,7 +15,7 @@ class PostmarkTest extends \Stampie\Tests\BaseMailerTest
     {
         parent::setUp();
 
-        $this->mailer = new Postmark(
+        $this->mailer = new TestPostmark(
             $this->adapter,
             self::SERVER_TOKEN
         );
@@ -69,5 +71,28 @@ class PostmarkTest extends \Stampie\Tests\BaseMailerTest
             array(400, '', 'Stampie\Exception\HttpException', 'Bad Request'),
             array(422, '{ "Message" : "Bad Credentials" }', 'Stampie\Exception\ApiException', 'Bad Credentials'),
         );
+    }
+}
+
+class TestPostmark extends Postmark
+{
+    public function getEndpoint()
+    {
+        return parent::getEndpoint();
+    }
+
+    public function handle(ResponseInterface $response)
+    {
+        parent::handle($response);
+    }
+
+    public function getHeaders()
+    {
+        return parent::getHeaders();
+    }
+
+    public function format(MessageInterface $message)
+    {
+        return parent::format($message);
     }
 }

--- a/tests/Stampie/Tests/Mailer/SendGridTest.php
+++ b/tests/Stampie/Tests/Mailer/SendGridTest.php
@@ -4,6 +4,8 @@ namespace Stampie\Tests\Mailer;
 
 use Stampie\Mailer\SendGrid;
 use Stampie\Adapter\Response;
+use Stampie\Adapter\ResponseInterface;
+use Stampie\MessageInterface;
 
 class SendGridTest extends \Stampie\Tests\BaseMailerTest
 {
@@ -13,7 +15,7 @@ class SendGridTest extends \Stampie\Tests\BaseMailerTest
     {
         parent::setUp();
 
-        $this->mailer = new SendGrid(
+        $this->mailer = new TestSendGrid(
             $this->adapter,
             self::SERVER_TOKEN
         );
@@ -83,5 +85,23 @@ class SendGridTest extends \Stampie\Tests\BaseMailerTest
             array(400, '{ "errors" : ["Error In an Array"] }', 'Stampie\Exception\ApiException'),
             array(500, '', 'Stampie\Exception\HttpException')
         );
+    }
+}
+
+class TestSendGrid extends SendGrid
+{
+    public function getEndpoint()
+    {
+        return parent::getEndpoint();
+    }
+
+    public function handle(ResponseInterface $response)
+    {
+        parent::handle($response);
+    }
+
+    public function format(MessageInterface $message)
+    {
+        return parent::format($message);
     }
 }

--- a/tests/Stampie/Tests/MailerTest.php
+++ b/tests/Stampie/Tests/MailerTest.php
@@ -33,11 +33,6 @@ class MailerTest extends \PHPUnit_Framework_TestCase
         $this->mailer->setServerToken('');
     }
 
-    public function testHeaders()
-    {
-        $this->assertEquals(array(), $this->mailer->getHeaders());
-    }
-
     public function testSendSuccessful()
     {
         $mailer = $this->mailer;


### PR DESCRIPTION
Methods used by the abstract mailer implementation during the send()
process are now protected methods instead of being part of the interface.

This corresponds to our IRC discussion.

Btw, when tagging 0.5.0, either update the `Stampie\Version::VERSION` constant or remove this class. An outdated version number is worse than no constant as it lead to false expectations for people doing a version check. It is still claiming 0.2.0 in the 0.4.0 release.
