### PR TITLE
Added the support for Identity objects to configure the name and email

### DIFF
--- a/lib/Stampie/Identity.php
+++ b/lib/Stampie/Identity.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Stampie;
+
+/**
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class Identity implements IdentityInterface
+{
+    private $email;
+    private $name;
+
+    public function __construct($email = null)
+    {
+        $this->email = $email;
+    }
+
+    public function setEmail($email)
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/lib/Stampie/IdentityInterface.php
+++ b/lib/Stampie/IdentityInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Stampie;
+
+/**
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+interface IdentityInterface
+{
+    /**
+     * @return string
+     */
+    public function getEmail();
+
+    /**
+     * @return string|null
+     */
+    public function getName();
+}

--- a/lib/Stampie/Mailer.php
+++ b/lib/Stampie/Mailer.php
@@ -125,4 +125,36 @@ abstract class Mailer implements MailerInterface
      * @throws \Stampie\Exception\HttpException
      */
     abstract protected function handle(ResponseInterface $response);
+
+    /**
+     * @param IdentityInterface|string $identity
+     *
+     * @return IdentityInterface
+     */
+    protected function normalizeIdentity($identity)
+    {
+        if (!$identity instanceof IdentityInterface) {
+            $identity = new Identity($identity);
+        }
+
+        return $identity;
+    }
+
+    /**
+     * @param IdentityInterface|string $identity
+     *
+     * @return string
+     */
+    protected function buildIdentityString($identity)
+    {
+        if ($identity instanceof IdentityInterface) {
+            if (null === $identity->getName()) {
+                return $identity->getEmail();
+            }
+
+            return sprintf('%s <%s>', $identity->getName(), $identity->getEmail());
+        }
+
+        return $identity;
+    }
 }

--- a/lib/Stampie/Mailer/MailChimpSts.php
+++ b/lib/Stampie/Mailer/MailChimpSts.php
@@ -33,14 +33,19 @@ class MailChimpSts extends Mailer
      */
     protected function format(MessageInterface $message)
     {
+        $from = $this->normalizeIdentity($message->getFrom());
+        $to = $this->normalizeIdentity($message->getTo());
+
         $parameters = array(
             'apikey'  => $this->getServerToken(),
             'message' => array_filter(array(
                 'html'       => $message->getHtml(),
                 'text'       => $message->getText(),
                 'subject'    => $message->getSubject(),
-                'to_email'   => $message->getTo(),
-                'from_email' => $message->getFrom(),
+                'to_email'   => array($to->getEmail()),
+                'to_name'    => array($to->getName()),
+                'from_email' => $from->getEmail(),
+                'from_name'  => $from->getName(),
             )),
         );
 

--- a/lib/Stampie/Mailer/MailGun.php
+++ b/lib/Stampie/Mailer/MailGun.php
@@ -58,13 +58,13 @@ class MailGun extends \Stampie\Mailer
         });
 
         $parameters = array(
-            'from'    => $message->getFrom(),
-            'to'      => $message->getTo(),
+            'from'    => $this->buildIdentityString($message->getFrom()),
+            'to'      => $this->buildIdentityString($message->getTo()),
             'subject' => $message->getSubject(),
             'text'    => $message->getText(),
             'html'    => $message->getHtml(),
-            'cc'      => $message->getCc(),
-            'bcc'     => $message->getBcc(),
+            'cc'      => $this->buildIdentityString($message->getCc()),
+            'bcc'     => $this->buildIdentityString($message->getBcc()),
         );
 
         return http_build_query(array_filter(array_merge($headers, $parameters)));

--- a/lib/Stampie/Mailer/Mandrill.php
+++ b/lib/Stampie/Mailer/Mandrill.php
@@ -42,11 +42,16 @@ class Mandrill extends Mailer
             $message->getHeaders(),
             array('Reply-To' => $message->getReplyTo())
         ));
+
+        $from = $this->normalizeIdentity($message->getFrom());
+        $to = $this->normalizeIdentity($message->getTo());
+
         $parameters = array(
             'key'     => $this->getServerToken(),
             'message' => array_filter(array(
-                'from_email' => $message->getFrom(),
-                'to'         => array(array('email' => $message->getTo())),
+                'from_email' => $from->getEmail(),
+                'from_name'  => $from->getName(),
+                'to'         => array(array('email' => $to->getEmail(), 'name' => $to->getName())),
                 'subject'    => $message->getSubject(),
                 'headers'    => $headers,
                 'text'       => $message->getText(),

--- a/lib/Stampie/Mailer/PeytzMail.php
+++ b/lib/Stampie/Mailer/PeytzMail.php
@@ -66,9 +66,9 @@ class PeytzMail extends \Stampie\Mailer
     protected function format(MessageInterface $message)
     {
         $parameters = array(
-            'email' => $message->getTo(),
+            'email' => $this->normalizeIdentity($message->getTo())->getEmail(),
             'subject' => $message->getSubject(),
-            'from_email' => $message->getFrom(),
+            'from_email' => $this->normalizeIdentity($message->getFrom())->getEmail(),
             'tag' => $message->getTag(),
             'content' => array(
                 'html' => $message->getHtml(),

--- a/lib/Stampie/Mailer/Postmark.php
+++ b/lib/Stampie/Mailer/Postmark.php
@@ -57,8 +57,8 @@ class Postmark extends Mailer
     protected function format(MessageInterface $message)
     {
         $parameters = array_filter(array(
-            'From'     => $message->getFrom(),
-            'To'       => $message->getTo(),
+            'From'     => $this->buildIdentityString($message->getFrom()),
+            'To'       => $this->buildIdentityString($message->getTo()),
             'Subject'  => $message->getSubject(),
             'Headers'  => $message->getHeaders(),
             'TextBody' => $message->getText(),

--- a/lib/Stampie/Mailer/SendGrid.php
+++ b/lib/Stampie/Mailer/SendGrid.php
@@ -60,15 +60,20 @@ class SendGrid extends Mailer
         // We should split up the ServerToken on : to get username and password
         list($username, $password) = explode(':', $this->getServerToken());
 
+        $from = $this->normalizeIdentity($message->getFrom());
+        $to = $this->normalizeIdentity($message->getTo());
+
         $parameters = array(
             'api_user' => $username,
             'api_key'  => $password,
-            'to'       => $message->getTo(),
-            'from'     => $message->getFrom(),
+            'to'       => $to->getEmail(),
+            'toname'   => $to->getName(),
+            'from'     => $from->getEmail(),
+            'fromname' => $from->getName(),
             'subject'  => $message->getSubject(),
             'text'     => $message->getText(),
             'html'     => $message->getHtml(),
-            'bcc'      => $message->getBcc(),
+            'bcc'      => $this->normalizeIdentity($message->getBcc())->getEmail(),
             'replyto'  => $message->getReplyTo(),
             'headers'  => json_encode($message->getHeaders()),
         );

--- a/lib/Stampie/MailerInterface.php
+++ b/lib/Stampie/MailerInterface.php
@@ -3,7 +3,6 @@
 namespace Stampie;
 
 use Stampie\Adapter\AdapterInterface;
-use Stampie\Adapter\ResponseInterface;
 
 /**
  * Takes a MailerInterface and sends to to Postmark throgh Buzz

--- a/lib/Stampie/Message.php
+++ b/lib/Stampie/Message.php
@@ -26,11 +26,12 @@ abstract class Message implements MessageInterface
     protected $text;
 
     /**
-     * @param string $to
+     * @param IdentityInterface|string $to
      */
     public function __construct($to)
     {
-        if (!filter_var($to, FILTER_VALIDATE_EMAIL)) {
+        $email = $to instanceof IdentityInterface ? $to->getEmail() : $to;
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
             throw new \InvalidArgumentException('Invalid email');
         }
 
@@ -55,7 +56,7 @@ abstract class Message implements MessageInterface
 
     /**
      * @param string $text
-     * @throws \InvalidArgument
+     * @throws \InvalidArgumentException
      */
     public function setText($text)
     {
@@ -83,7 +84,7 @@ abstract class Message implements MessageInterface
     }
 
     /**
-     * @return true
+     * @return array
      */
     public function getHeaders()
     {

--- a/lib/Stampie/MessageInterface.php
+++ b/lib/Stampie/MessageInterface.php
@@ -11,22 +11,22 @@ namespace Stampie;
 interface MessageInterface
 {
     /**
-     * @return string
+     * @return IdentityInterface|string
      */
     function getFrom();
 
     /**
-     * @return string
+     * @return IdentityInterface|string
      */
     function getTo();
 
     /**
-     * @return string
+     * @return IdentityInterface|string
      */
     function getCc();
 
     /**
-     * @return $string
+     * @return IdentityInterface|$string
      */
     function getBcc();
 

--- a/tests/Stampie/Tests/Mailer/MailChimpStsTest.php
+++ b/tests/Stampie/Tests/Mailer/MailChimpStsTest.php
@@ -47,7 +47,8 @@ class MailChimpStsTest extends BaseMailerTest
             'message' => array(
                 'html' => $html,
                 'subject' => $subject,
-                'to_email' => $to,
+                'to_email' => array($to),
+                'to_name' => array(null),
                 'from_email' => $from,
             ),
         )), $this->mailer->format($message));

--- a/tests/Stampie/Tests/Mailer/MandrillTest.php
+++ b/tests/Stampie/Tests/Mailer/MandrillTest.php
@@ -46,7 +46,7 @@ class MandrillTest extends \Stampie\Tests\BaseMailerTest
             'key' => self::SERVER_TOKEN,
             'message' => array(
                 'from_email' => $from,
-                'to' => array(array('email' => $to)),
+                'to' => array(array('email' => $to, 'name' => null)),
                 'subject' => $subject,
                 'html' => $html,
             ),


### PR DESCRIPTION
As discussed on IRC, this allows changing the sender and recipient names.

The implementation is incomplete for PeytzMail as I'm unable to find their documentation. Their domain name is returning a 404.

I'm wondering if we should also support `array<IdentityInterface>` as a valid return value for To, Cc and Bcc to allow multiple values.
