### PR TITLE
Fixed the support of tags for Sendgrid

### DIFF
--- a/lib/Stampie/Mailer/SendGrid.php
+++ b/lib/Stampie/Mailer/SendGrid.php
@@ -80,7 +80,7 @@ class SendGrid extends Mailer
         );
 
         if ($message instanceof TaggableInterface) {
-            $parameters['x-smtpapi']['category'] = (array) $message->getTag();
+            $parameters['x-smtpapi'] = json_encode(array('category' => (array) $message->getTag()));
         }
 
         return http_build_query(array_filter($parameters));

--- a/tests/Stampie/Tests/Mailer/SendGridTest.php
+++ b/tests/Stampie/Tests/Mailer/SendGridTest.php
@@ -93,7 +93,7 @@ class SendGridTest extends \Stampie\Tests\BaseMailerTest
         $query = compact(
             'api_user', 'api_key', 'to', 'from', 'subject', 'html', 'headers'
         );
-        $query['x-smtpapi']['category'] = array($tag);
+        $query['x-smtpapi'] = json_encode(array('category' => array($tag)));
 
 
         $this->assertEquals(http_build_query(


### PR DESCRIPTION
The x-smtpapi parameter needs to be json-encoded in the query.
