### PR TITLE
Added the support of metadata on messages with MetadataAwareInterface

### DIFF
--- a/lib/Stampie/Mailer/MailGun.php
+++ b/lib/Stampie/Mailer/MailGun.php
@@ -3,6 +3,7 @@
 namespace Stampie\Mailer;
 
 use Stampie\Mailer;
+use Stampie\Message\MetadataAwareInterface;
 use Stampie\MessageInterface;
 use Stampie\Message\TaggableInterface;
 use Stampie\Adapter\ResponseInterface;
@@ -73,7 +74,16 @@ class MailGun extends Mailer
             $parameters['o:tag'] = (array) $message->getTag();
         }
 
-        return http_build_query(array_filter(array_merge($headers, $parameters)));
+        $metadata = array();
+        if ($message instanceof MetadataAwareInterface) {
+            $metadata = array_filter($message->getMetadata());
+            // Custom variables should be prefixed with v:my_var
+            array_walk($metadata, function (&$value, &$key) {
+                $key = 'v:' . $key;
+            });
+        }
+
+        return http_build_query(array_filter(array_merge($headers, $parameters, $metadata)));
     }
 
     /**

--- a/lib/Stampie/Mailer/Mandrill.php
+++ b/lib/Stampie/Mailer/Mandrill.php
@@ -3,6 +3,7 @@
 namespace Stampie\Mailer;
 
 use Stampie\Mailer;
+use Stampie\Message\MetadataAwareInterface;
 use Stampie\MessageInterface;
 use Stampie\Message\TaggableInterface;
 use Stampie\Adapter\ResponseInterface;
@@ -56,6 +57,11 @@ class Mandrill extends Mailer
             $tags = (array) $message->getTag();
         }
 
+        $metadata = array();
+        if ($message instanceof MetadataAwareInterface) {
+            $metadata = array_filter($message->getMetadata());
+        }
+
         $parameters = array(
             'key'     => $this->getServerToken(),
             'message' => array_filter(array(
@@ -67,6 +73,7 @@ class Mandrill extends Mailer
                 'text'       => $message->getText(),
                 'html'       => $message->getHtml(),
                 'tags'       => $tags,
+                'metadata'   => $metadata,
             )),
         );
 

--- a/lib/Stampie/Message/MetadataAwareInterface.php
+++ b/lib/Stampie/Message/MetadataAwareInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Stampie\Message;
+
+/**
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+interface MetadataAwareInterface
+{
+    /**
+     * Gets the metadata attached to the message.
+     *
+     * Message metadata allow to attach some additional information to the message.
+     * This can typically be used to attach a customer id to the sent messages.
+     *
+     * Providers supporting this feature will then give some filtering or tracking
+     * capabilities.
+     *
+     * @return array An associative array of metadata
+     */
+    public function getMetadata();
+}

--- a/lib/Stampie/Message/TaggableInterface.php
+++ b/lib/Stampie/Message/TaggableInterface.php
@@ -8,6 +8,14 @@ namespace Stampie\Message;
 interface TaggableInterface
 {
     /**
+     * The tag(s) attached to the message.
+     *
+     * Tags should typically be used to distinguish the different categories of messages
+     * sent by your application (invitation, password recovery, notification...).
+     *
+     * Most providers supporting this feature only allow to use a limited number of tags
+     * in the application.
+     *
      * @return string|array
      */
     public function getTag();

--- a/tests/Stampie/Tests/BaseMailerTest.php
+++ b/tests/Stampie/Tests/BaseMailerTest.php
@@ -58,6 +58,21 @@ abstract class BaseMailerTest extends \PHPUnit_Framework_TestCase
         return $message;
     }
 
+    protected function getMetadataAwareMessageMock($from, $to, $subject, $html = null, $text = null, array $headers = array(), array $metadata = array())
+    {
+        $message = $this->getMock('Stampie\Tests\Mailer\MetadataAwareMessage');
+
+        $this->configureMessageMock($message, $from, $to, $subject, $html, $text, $headers);
+
+        $message
+            ->expects($this->any())
+            ->method('getMetadata')
+            ->will($this->returnValue($metadata))
+        ;
+
+        return $message;
+    }
+
     private function configureMessageMock(\PHPUnit_Framework_MockObject_MockObject $message, $from, $to, $subject, $html = null, $text = null, array $headers = array())
     {
         $message

--- a/tests/Stampie/Tests/Mailer/MailGunTest.php
+++ b/tests/Stampie/Tests/Mailer/MailGunTest.php
@@ -11,6 +11,13 @@ class MailGunTest extends \PHPUnit_Framework_TestCase
 {
     const SERVER_TOKEN = 'henrik.bjrnskov.dk:myCustomKey';
 
+    private $adapter;
+
+    /**
+     * @var TestMailGun
+     */
+    private $mailer;
+
     public function setUp()
     {
         $this->adapter = $this->createMockAdapter();
@@ -18,7 +25,7 @@ class MailGunTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testServerTokenMissingDelimeter()
     {

--- a/tests/Stampie/Tests/Mailer/MandrillTest.php
+++ b/tests/Stampie/Tests/Mailer/MandrillTest.php
@@ -79,6 +79,32 @@ class MandrillTest extends \Stampie\Tests\BaseMailerTest
         )), $this->mailer->format($message));
     }
 
+    public function testFormatMetadataAware()
+    {
+        $message = $this->getMetadataAwareMessageMock(
+            $from = 'hb@peytz.dk',
+            $to = 'henrik@bjrnskov.dk',
+            $subject = 'Stampie is awesome',
+            $html = 'So what do you thing',
+            $text = 'text',
+            $headers = array('X-Stampie-To' => 'henrik+to@bjrnskov.dk'),
+            $metadata = array('client_name' => 'Stampie')
+        );
+
+        $this->assertEquals(json_encode(array(
+            'key' => self::SERVER_TOKEN,
+            'message' => array(
+                'from_email' => $from,
+                'to' => array(array('email' => $to, 'name' => null)),
+                'subject' => $subject,
+                'headers' => $headers,
+                'text' => $text,
+                'html' => $html,
+                'metadata' => $metadata
+            ),
+        )), $this->mailer->format($message));
+    }
+
     /**
      * @dataProvider handleDataProvider
      */

--- a/tests/Stampie/Tests/Mailer/MetadataAwareMessage.php
+++ b/tests/Stampie/Tests/Mailer/MetadataAwareMessage.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Stampie\Tests\Mailer;
+
+use Stampie\MessageInterface;
+use Stampie\Message\MetadataAwareInterface;
+
+abstract class MetadataAwareMessage implements MessageInterface, MetadataAwareInterface
+{
+}

--- a/tests/Stampie/Tests/Mailer/SendGridTest.php
+++ b/tests/Stampie/Tests/Mailer/SendGridTest.php
@@ -103,6 +103,37 @@ class SendGridTest extends \Stampie\Tests\BaseMailerTest
         ), $this->mailer->format($message));
     }
 
+    public function testFormatMetadataAware()
+    {
+        $api_user = 'rudolph';
+        $api_key = 'rednose';
+
+        $message =  $this->getMetadataAwareMessageMock(
+            $from = 'henrik@bjrnskov.dk',
+            $to = 'hb@peytz.dk',
+            $subject = 'Trying out Stampie',
+            $html = 'Stampie is Awesome',
+            $text = '',
+            $headers = array(
+                'X-Custom-Header' => 'My Custom Header Value',
+            ),
+            $metadata = array('client_name' => 'Stampie')
+        );
+
+        $headers = json_encode($headers);
+        $to = array($to);
+
+        $query = compact(
+            'api_user', 'api_key', 'to', 'from', 'subject', 'html', 'headers'
+        );
+        $query['x-smtpapi'] = json_encode(array('unique_args' => $metadata));
+
+
+        $this->assertEquals(http_build_query(
+            $query
+        ), $this->mailer->format($message));
+    }
+
     public function handleDataProvider()
     {
         return array(


### PR DESCRIPTION
This is supported by Mandrill, Sendgrid and Mailgun. Postmark and
MailchimpSts don't have the equivalent feature.
