### PR TITLE
Fixed the handling of ReplyTo in the abstract message class

### DIFF
--- a/lib/Stampie/Message.php
+++ b/lib/Stampie/Message.php
@@ -96,7 +96,13 @@ abstract class Message implements MessageInterface
      */
     public function getReplyTo()
     {
-        return $this->getFrom();
+        $from = $this->getFrom();
+
+        if ($from instanceof IdentityInterface) {
+            $from = $from->getEmail();
+        }
+
+        return $from;
     }
 
     /**


### PR DESCRIPTION
getReplyTo should always return a string, even when getFrom returns an identity.
