### PR TITLE
Returning Stampie\Adapter\Response object on successful response.

### DIFF
--- a/lib/Stampie/Mailer.php
+++ b/lib/Stampie/Mailer.php
@@ -83,7 +83,9 @@ abstract class Mailer implements MailerInterface
 
         // We are all clear if status is HTTP 2xx OK
         if ($response->isSuccessful()) {
-            return true;
+            // Send back the contents from the response. Successful Postmark API response has the message ID
+            // on it which can be used to logs the email responses.
+            return $response;
         }
 
         return $this->handle($response);


### PR DESCRIPTION
On receiving a successful response for an email, we send back a boolean true.

There is a need sometimes to log futther  Instead we can send back the Response object and let the 'Message ID' from postmark. Returning back the response object will give more leverage to the calling function.

Thanks,
-Ketan.
