### PR TITLE
Fixed issue when \Stampie\Identity('email_address@gmail.com') is used to...

### DIFF
--- a/lib/Stampie/Util/IdentityUtils.php
+++ b/lib/Stampie/Util/IdentityUtils.php
@@ -46,6 +46,10 @@ class IdentityUtils
             $identities = array(self::normalizeIdentity($identities));
         }
 
+        if (!is_array($identities) && $identities instanceof IdentityInterface) {
+            $identities = array($identities);
+        }
+
         return $identities;
     }
 


### PR DESCRIPTION
... create a Message but the 'to' email does not come in the final formatted params.
