### PR TITLE
Verify success from the response content when from API response code is ...

### DIFF
--- a/lib/Stampie/Mailer.php
+++ b/lib/Stampie/Mailer.php
@@ -81,8 +81,9 @@ abstract class Mailer implements MailerInterface
             $this->getHeaders()
         );
 
-        // We are all clear if status is HTTP 2xx OK
-        if ($response->isSuccessful()) {
+        // We are clear if status is HTTP 2xx OK and are able to verify success
+        // in the response from the API
+        if ($response->isSuccessful() && $this->verifySuccess($response)) {
             return true;
         }
 
@@ -128,6 +129,24 @@ abstract class Mailer implements MailerInterface
      * @throws \Stampie\Exception\HttpException
      */
     abstract protected function handle(ResponseInterface $response);
+
+    /**
+     * If a Response is successful it will be passed to this method
+     * each Mailer should parse the response to validate the success
+     * or then throw an HttpException with an optional
+     * ApiException to help identify the problem.
+     *
+     * @param ResponseInterface $response
+     *
+     * @throws \Stampie\Exception\ApiException
+     * @throws \Stampie\Exception\HttpException
+     * @return boolean
+     */
+    protected function verifySuccess(ResponseInterface $response)
+    {
+        // default implemetation for Mailers who skip this
+        return true;
+    }
 
     /**
      * @param IdentityInterface|string $identity

--- a/lib/Stampie/Mailer/Mandrill.php
+++ b/lib/Stampie/Mailer/Mandrill.php
@@ -100,4 +100,27 @@ class Mandrill extends Mailer
 
         throw new ApiException($error->message, $httpException, $error->code);
     }
+
+    /**
+     * Verify success from the reponse of the API in HTTP 200 OK scenario
+     */
+    protected function verifySuccess(ResponseInterface $response)
+    {
+        $parsed_response = json_decode($response->getContent());
+        $errors = array();
+
+        if(is_array($parsed_response)) {
+            foreach ($parsed_response as $email) {
+                if($email->status !== "sent") {
+                    $errors[] = "Email to {$email->email} was {$email->status} because {$email->reject_reason}";
+                }
+            }
+        }
+
+        if(!empty($errors)) {
+            throw new ApiException(implode(' & ', $errors));
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
...HTTP 200 OK

Sample 200 OK responses from Mandrill:

```
[
    {
        "email": "name@domain.com",
        "status": "sent",
        "_id": "e985ec5dbced4fcd9eae1226ec475a55",
        "reject_reason": null
    }
]

[
    {
        "email": "name@domain.com",
        "status": "rejected",
        "_id": "e985ec5dbced4fcd9eae1226ec475a55",
        "reject_reason": "invalid-sender"
    }
]
```
