### PR TITLE
Disable Guzzle exception for error responses

### DIFF
--- a/lib/Stampie/Adapter/Guzzle.php
+++ b/lib/Stampie/Adapter/Guzzle.php
@@ -41,7 +41,7 @@ class Guzzle implements AdapterInterface
      */
     public function send($endpoint, $content, array $headers = array())
     {
-        $request = $this->client->createRequest(RequestInterface::POST, $endpoint, $headers, $content);
+        $request = $this->client->createRequest(RequestInterface::POST, $endpoint, $headers, $content, array('exceptions' => false));
         $response = $request->send();
 
         return new Response($response->getStatusCode(), $response->getBody(true));


### PR DESCRIPTION
Our HTTP client is expected to return the response for 4xx and 5xx, not to throw an exception.

this is probably the reason why #32 throws a guzzle exception here
