### PR TITLE
Change the Guzzle3 typehint to allow using guzzle/http only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,13 +28,13 @@
         "php"                : ">=5.3.3"
     },
     "require-dev" : {
-        "kriswallsmith/buzz" : "*",
-        "guzzle/guzzle"      : "*"
+        "kriswallsmith/buzz" : "~0.8",
+        "guzzle/http"        : "~3"
     },
     "suggest" : {
         "stof/stampie-extra" : "Extensions for Stampie",
         "kriswallsmith/buzz" : "Lightweight HTTP Client",
-        "guzzle/guzzle"      : "HTTP Client and Framework for building RESTful webservice clients"
+        "guzzle/http"        : "HTTP Client and Framework for building RESTful webservice clients"
     },
     "extra": {
         "branch-alias": {

--- a/lib/Stampie/Adapter/Guzzle.php
+++ b/lib/Stampie/Adapter/Guzzle.php
@@ -2,7 +2,7 @@
 
 namespace Stampie\Adapter;
 
-use Guzzle\Service\Client;
+use Guzzle\Http\ClientInterface;
 use Guzzle\Http\Message\RequestInterface;
 use Guzzle\Http\Message\EntityEnclosingRequestInterface;
 
@@ -14,20 +14,20 @@ use Guzzle\Http\Message\EntityEnclosingRequestInterface;
 class Guzzle implements AdapterInterface
 {
     /**
-     * @var Client
+     * @var ClientInterface
      */
     protected $client;
 
     /**
-     * @param Client $client
+     * @param ClientInterface $client
      */
-    public function __construct(Client $client)
+    public function __construct(ClientInterface $client)
     {
         $this->client = $client;
     }
 
     /**
-     * @return Client
+     * @return ClientInterface
      */
     public function getClient()
     {
@@ -39,6 +39,7 @@ class Guzzle implements AdapterInterface
      * @param string $content
      * @param array $headers
      * @param array $files
+     *
      * @return Response
      */
     public function send($endpoint, $content, array $headers = array(), array $files = array())

--- a/tests/Stampie/Tests/Adapter/GuzzleTest.php
+++ b/tests/Stampie/Tests/Adapter/GuzzleTest.php
@@ -7,16 +7,18 @@ use Guzzle\Http\Message\RequestInterface;
 
 class GuzzleTest extends \PHPUnit_Framework_TestCase
 {
+    private $client;
+
     public function setUp()
     {
-        if (!class_exists('Guzzle\Service\Client')) {
-            $this->markTestSkipped('Cannot find Guzzle\Service\Client');
+        if (!interface_exists('Guzzle\Http\ClientInterface')) {
+            $this->markTestSkipped('Cannot find Guzzle\Http\ClientInterface');
         }
 
-        $this->client = $this->getMock('Guzzle\Service\Client');
+        $this->client = $this->getMock('Guzzle\Http\ClientInterface');
     }
 
-    public function testAccesibility()
+    public function testAccessibility()
     {
         $adapter = new Guzzle($this->client);
         $this->assertEquals($this->client, $adapter->getClient());
@@ -66,7 +68,7 @@ class GuzzleTest extends \PHPUnit_Framework_TestCase
                 $this->equalTo('http://google.com'),
                 $this->equalTo(array(
                     'Content-Type' => 'application/json',
-                    'X-Postmark-Server-Token' => 'MySuperToken', 
+                    'X-Postmark-Server-Token' => 'MySuperToken',
                 )),
                 $this->equalTo('content')
             )


### PR DESCRIPTION
The typehint should rely on the interface, not on the implementation.
And the parent HTTP client is enough for what the adapter does, allowing to use a much smaller dependency.
