### PR TITLE
Fix the branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.11.x-dev"
+            "dev-master": "1.0.x-dev"
         }
     }
 }


### PR DESCRIPTION
1.0-alpha1 was released already, so dev-master is not 0.11.x-dev anymore.