### PR TITLE
Fix missing tags when sending attachments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php-http/httplug"                  : "^1.0",
         "php-http/message-factory"          : "^1.0",
         "php-http/discovery"                : "^1.0",
-        "php-http/multipart-stream-builder" : "^0.1",
+        "php-http/multipart-stream-builder" : "^0.2",
         "php-http/client-implementation"    : "^1.0"
     },
     "require-dev" : {


### PR DESCRIPTION
The mailer [assumes](https://github.com/flint/Stampie/blob/c6e19222994ce60f101b0a00c413de30100f9580/lib/Stampie/Mailer.php#L224-L226) that multiple calls to `Http\Message\MultipartStream\MultipartStreamBuilder::addResource()` do not overwrite resources with the same name. This behaviour is only implemented in ≥0.2.0. Previously, resources with the same name were overwritten.


Example (two tags, *foo* and *bar*, should be included in the request):

```php
class Message extends \Stampie\Message implements \Stampie\Message\TaggableInterface, \Stampie\Message\AttachmentsAwareInterface
{
    public function getFrom() { return 'alias@domain.tld'; }
    public function getSubject() { return 'You are trying out Stampie'; }
    public function getText() { return 'So what do you think about it?'; }
    public function getTag() { return ['foo', 'bar']; }
    public function getAttachments() { return [new \Stampie\Attachment('/dev/null')]; }
}

class MessageTest extends \PHPUnit_Framework_TestCase
{
    public function testSameResourceName()
    {
        $adapter = $this->getMockBuilder('Http\\Client\\HttpClient')->getMock();
        $adapter->method('sendRequest')->with($this->callback(function ($request) {
            return strpos(\GuzzleHttp\Psr7\str($request), 'foo') !== false;
        }))->willReturn(new \GuzzleHttp\Psr7\Response());

        $mailer = new \Stampie\Mailer\MailGun($adapter, 'api:key-xxx');
        $mailer->send(new Message('receiver@domain.tld'));
    }
}
```