### PR TITLE
Sendgrid attachments fix

### DIFF
--- a/lib/Stampie/Mailer/SendGrid.php
+++ b/lib/Stampie/Mailer/SendGrid.php
@@ -56,7 +56,9 @@ class SendGrid extends Mailer
         // Format params
         $files = array();
         if ($attachments) {
-            $files['files'] = $attachments;
+            foreach ($attachments as $key => $value) {
+                $files['files['.$key.']'][] = $value;
+            }
         }
         return $files;
     }


### PR DESCRIPTION
As per the sendgrid document, attachment should be send in files[filename] format. https://sendgrid.com/docs/API_Reference/Web_API/mail.html#-Send-a-test-with-attachment