### PR TITLE
Bugfix, make sure to quote the boundary.

### DIFF
--- a/lib/Stampie/Mailer.php
+++ b/lib/Stampie/Mailer.php
@@ -243,7 +243,7 @@ abstract class Mailer implements MailerInterface
             }
 
             $content = $builder->build();
-            $headers['Content-Type'] = 'multipart/form-data; boundary='.$builder->getBoundary();
+            $headers['Content-Type'] = 'multipart/form-data; boundary="'.$builder->getBoundary().'"';
         }
 
         $request = $this->getMessageFactory()->createRequest('POST', $this->getEndpoint(), $headers, $content);

--- a/lib/Stampie/Mailer.php
+++ b/lib/Stampie/Mailer.php
@@ -134,7 +134,7 @@ abstract class Mailer implements MailerInterface
      * Return an key -> value array of files
      *
      * example:
-     *     array('attachmentname.jpg' => '/path/to/file.jpg')
+     *     ['foo_files' => array('attachmentname.jpg' => '/path/to/file.jpg')]
      *
      * @param MessageInterface $message
      * @return string[]

--- a/tests/Stampie/Tests/MailerTest.php
+++ b/tests/Stampie/Tests/MailerTest.php
@@ -2,8 +2,10 @@
 
 namespace Stampie\Tests;
 
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use Stampie\Mailer\MailGun;
 
 class MailerTest extends \PHPUnit_Framework_TestCase
 {
@@ -79,6 +81,38 @@ class MailerTest extends \PHPUnit_Framework_TestCase
         ;
 
         $this->mailer->send($this->getMock('Stampie\MessageInterface'));
+    }
+
+
+    public function testSendWithFiles()
+    {
+        $adapter = $this->httpClient;
+        $mailer = $this->getMockBuilder(MailGun::class)
+            ->setConstructorArgs([$adapter, 'Token:bar'])
+            ->setMethods(['format', 'getFiles'])
+            ->getMock();
+
+        $mailer
+            ->expects($this->once())
+            ->method('format');
+
+        $mailer
+            ->expects($this->once())
+            ->method('getFiles')
+            ->willReturn(['files' => ['foo'=> __DIR__ . '/../../Fixtures/logo.png']]);
+
+        $adapter
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function(RequestInterface $request) {
+                return preg_match('|multipart/form-data; boundary="[a-zA-Z0-9\._]+"|sim', $request->getHeaderLine('Content-Type'));
+            }))
+            ->will($this->returnValue(
+                $this->getResponseMock(true)
+            ))
+        ;
+
+        $this->assertTrue($mailer->send($this->getMock('Stampie\MessageInterface')));
     }
 
     /**


### PR DESCRIPTION
The boundary may contain a period. If so, we MUST quote the string. 