### PR TITLE
Ensure normalizeIdentities handles array containing strings

### DIFF
--- a/lib/Util/IdentityUtils.php
+++ b/lib/Util/IdentityUtils.php
@@ -40,6 +40,10 @@ class IdentityUtils
      */
     public static function normalizeIdentities($identities)
     {
+        if (is_array($identities)) {
+            $identities = array_map([__CLASS__, 'normalizeIdentity'], $identities);
+        }
+
         if (null === $identities) {
             return [];
         }

--- a/tests/Stampie/Tests/Util/IdentityUtilsTest.php
+++ b/tests/Stampie/Tests/Util/IdentityUtilsTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Stampie\Tests\Util;
+
+use Stampie\Identity;
+use Stampie\IdentityInterface;
+use Stampie\Util\IdentityUtils;
+
+/**
+ * @coversDefaultClass \Stampie\Util\IdentityUtils
+ */
+class IdentityUtilsTest extends \PHPUnit_Framework_TestCase
+{
+    public function normalizeIdentityScenarios()
+    {
+        return [
+            ['john@example.com'],
+            [new Identity('john@example.com')],
+        ];
+    }
+
+    public function normalizeIdentitiesScenarios()
+    {
+        return [
+            [['john@example.com', 'bob@example.com']],
+            [null],
+            ['john@example.com'],
+            [new Identity('john@example.com')],
+        ];
+    }
+
+    public function buildIdentityStringScenarios()
+    {
+        return [
+            [null, ''],
+            ['john@example.com', 'john@example.com'],
+            [new Identity('john@example.com', 'John'), 'John <john@example.com>'],
+            [
+                [
+                    new Identity('john@example.com', 'John'),
+                    new Identity('bob@example.com', 'Bob'),
+                    new Identity('charlie@example.com')
+                ],
+                'John <john@example.com>,Bob <bob@example.com>,charlie@example.com'
+            ],
+        ];
+    }
+
+    /**
+     * @covers ::normalizeIdentity
+     * @dataProvider normalizeIdentityScenarios
+     */
+    public function testNormalizeIdentity($identity)
+    {
+        $this->assertInstanceOf(IdentityInterface::class, IdentityUtils::normalizeIdentity($identity));
+    }
+
+    /**
+     * @covers ::normalizeIdentities
+     * @dataProvider normalizeIdentitiesScenarios
+     */
+    public function testNormalizeIdentities($identities)
+    {
+        $normalizedIdentities = IdentityUtils::normalizeIdentities($identities);
+        $this->assertInternalType('array', $normalizedIdentities);
+        foreach ($normalizedIdentities as $identity) {
+            $this->assertInstanceOf(IdentityInterface::class, $identity);
+        }
+    }
+
+    /**
+     * @covers ::buildIdentityString
+     * @dataProvider buildIdentityStringScenarios
+     */
+    public function testBuildIdentityString($identities, $expected)
+    {
+        $this->assertSame($expected, IdentityUtils::buildIdentityString($identities));
+    }
+}


### PR DESCRIPTION
`IdentityUtils::normalizeIdentities` currently doesn't handle arrays whose elements are not all instances of `IdentityInterface`.

This PR normalizes arrays and also adds tests for the other methods in IdentityUtils.