### PR TITLE
Make MailerInterface lightweight

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@ The change log describes what been "Added", "Removed", "Changed" or "Fixed" betw
 ### Unreleased
 
 - The `setHttpClient`, `setServerToken` and `getServerToken` methods have been removed from `Stampie\MailerInterface`.
-- The `Stampie\MailerInterface::send` method no longer return a boolean. Errors are now reported using exceptions that implements `Stampie\ExceptionInterface`.
+- The `Stampie\MailerInterface::send` method no longer return a boolean. Errors are now reported using exceptions that implements `Stampie\ExceptionInterface`. As core mailers were already throwing exceptions when sending a message, the BC break impact is limited.
 
 ### 1.0.0-alpha2
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@ The change log describes what been "Added", "Removed", "Changed" or "Fixed" betw
 
 ### Unreleased
 
+- The `setHttpClient`, `setServerToken` and `getServerToken` methods have been removed from `Stampie\MailerInterface`.
+- The `Stampie\MailerInterface::send` method no longer return a boolean. Errors are now reported using exceptions that implements `Stampie\ExceptionInterface`.
 
 ### 1.0.0-alpha2
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ class Message extends \Stampie\Message
 $adapter = new Http\Adapter\Guzzle6\Client();
 $mailer = new Stampie\Mailer\SendGrid($adapter, 'username:password');
 
-// Returns Boolean true on success or throws an HttpException for error
+// Throws an HttpException for error
 // messages not recognized by SendGrid api or ApiException for known errors.
 $mailer->send(new Message('reciever@domain.tld'));
 ```

--- a/lib/Exception/ApiException.php
+++ b/lib/Exception/ApiException.php
@@ -2,12 +2,14 @@
 
 namespace Stampie\Exception;
 
+use Stampie\ExceptionInterface;
+
 /**
  * SubException.
  *
  * @author Henrik Bjornskov <henrik@bjrnskov.dk>
  */
-class ApiException extends \RuntimeException
+class ApiException extends \RuntimeException implements ExceptionInterface
 {
     /**
      * @param string     $message

--- a/lib/Exception/HttpException.php
+++ b/lib/Exception/HttpException.php
@@ -2,13 +2,15 @@
 
 namespace Stampie\Exception;
 
+use Stampie\ExceptionInterface;
+
 /**
  * Exception thrown for all HTTP Error codes where the Api's doesn't themselves provide an error
  * message.
  *
  * @author Henrik Bjornskov <henrik@bjrnskov.dk>
  */
-class HttpException extends \RuntimeException
+class HttpException extends \RuntimeException implements ExceptionInterface
 {
     /**
      * @param int        $statusCode

--- a/lib/ExceptionInterface.php
+++ b/lib/ExceptionInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Stampie;
+
+/**
+ * Every Stampie related exception must implement this interface.
+ */
+interface ExceptionInterface
+{
+}

--- a/lib/Mailer.php
+++ b/lib/Mailer.php
@@ -109,10 +109,10 @@ abstract class Mailer implements MailerInterface
 
         // We are all clear if status is HTTP 2xx OK
         if ($response->isSuccessful()) {
-            return true;
+            return;
         }
 
-        return $this->handle($response);
+        $this->handle($response);
     }
 
     /**

--- a/lib/MailerInterface.php
+++ b/lib/MailerInterface.php
@@ -9,7 +9,7 @@ interface MailerInterface
      *
      * @param MessageInterface $message
      *
-     * @throws ExceptionInterface if an error happens during sending the message.
+     * @throws ExceptionInterface if an error happens while sending the message.
      */
     public function send(MessageInterface $message);
 }

--- a/lib/MailerInterface.php
+++ b/lib/MailerInterface.php
@@ -9,7 +9,7 @@ interface MailerInterface
      *
      * @param MessageInterface $message
      *
-     * @throws \Exception if an error happens during sending the message.
+     * @throws ExceptionInterface if an error happens during sending the message.
      */
     public function send(MessageInterface $message);
 }

--- a/lib/MailerInterface.php
+++ b/lib/MailerInterface.php
@@ -2,34 +2,14 @@
 
 namespace Stampie;
 
-use Http\Client\HttpClient;
-
-/**
- * Takes a MailerInterface and sends to an AdapterInterface.
- *
- * @author Henrik Bjornskov <henrik@bjrnskov.dk>
- */
 interface MailerInterface
 {
     /**
-     * @param HttpClient $adapter
-     */
-    public function setHttpClient(HttpClient $adapter);
-
-    /**
-     * @param string $token
-     */
-    public function setServerToken($token);
-
-    /**
-     * @return string
-     */
-    public function getServerToken();
-
-    /**
+     * Sends an email message.
+     *
      * @param MessageInterface $message
      *
-     * @return bool
+     * @throws \Exception if an error happens during sending the message.
      */
     public function send(MessageInterface $message);
 }

--- a/tests/Stampie/Tests/MailerTest.php
+++ b/tests/Stampie/Tests/MailerTest.php
@@ -63,7 +63,7 @@ class MailerTest extends TestCase
                 $this->getResponseMock(true)
             ));
 
-        $this->assertTrue($this->mailer->send($this->getMockBuilder('Stampie\MessageInterface')->getMock()));
+        $this->mailer->send($this->getMockBuilder('Stampie\MessageInterface')->getMock());
     }
 
     public function testUnsuccessfulSendCallsHandle()
@@ -111,7 +111,7 @@ class MailerTest extends TestCase
             ))
         ;
 
-        $this->assertTrue($mailer->send($this->getMockBuilder('Stampie\MessageInterface')->getMock()));
+        $mailer->send($this->getMockBuilder('Stampie\MessageInterface')->getMock());
     }
 
     /**


### PR DESCRIPTION
This remove the `setHttpClient`, `setServerToken` and `getServerToken` from `MailerInterface`.

The `MailerInterface` contract is now only about sending messages without exposing implementation details to clients.

Also the `MailerInterface::send` method no longer returns a boolean. If no
exception is thrown, then the message was successfully sent.

Close #93.

## Todo

- [x] Update mailers to not return a boolean.
- [x] Introduce our own exception interface.
- [x] Add changelog entries.
