### PR TITLE
add Mandrill subaccount support

### DIFF
--- a/lib/Mailer/Mandrill.php
+++ b/lib/Mailer/Mandrill.php
@@ -21,6 +21,19 @@ use Stampie\Util\AttachmentUtils;
 class Mandrill extends Mailer
 {
     /**
+     * @var string
+     */
+    private $subaccount;
+
+    /**
+     * @param string $subaccount
+     */
+    public function setSubaccount($subaccount)
+    {
+        $this->subaccount = $subaccount;
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getEndpoint()
@@ -95,6 +108,10 @@ class Mandrill extends Mailer
                 'images'      => $images,
             ]),
         ];
+
+        if ($this->subaccount) {
+            $parameters['message']['subaccount'] = $this->subaccount;
+        }
 
         return json_encode($parameters);
     }

--- a/tests/Stampie/Tests/Mailer/MandrillTest.php
+++ b/tests/Stampie/Tests/Mailer/MandrillTest.php
@@ -194,6 +194,25 @@ class MandrillTest extends TestCase
         $this->mailer->send($message);
     }
 
+    public function testSendWithSubaccount()
+    {
+        $message = $this->getMessageMock('bob@example.com', 'alice@example.com', 'Stampie is awesome!');
+
+        $this->httpClient
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function (Request $request) {
+                $body = json_decode((string) $request->getBody(), true);
+
+                return $body['message']['subaccount'] === 'sub';
+            }))
+            ->willReturn(new Response())
+        ;
+
+        $this->mailer->setSubaccount('sub');
+        $this->mailer->send($message);
+    }
+
     /**
      * @dataProvider carbonCopyProvider
      *


### PR DESCRIPTION
This allows to use the Mandrill subaccount.

Implements #92.