### PR TITLE
Fix the Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: php
 
 php:
-    - 5.5
     - 5.6
     - 7.0
     - 7.1
     - 7.2
     - 7.3
+
+matrix:
+    include:
+        - php: 5.5
+          dist: trusty
 
 sudo: false
 
@@ -14,8 +18,8 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-before_script:
+install:
     - composer update
 
-script: 
+script:
   - ./vendor/bin/phpunit


### PR DESCRIPTION
The default distribution is now xenial, but it only supports PHP 5.6+ so we need to force using trusty for PHP 5.5.