### PR TITLE
Add support for HTTPlug 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require" : {
         "php"                               : "^5.5 || ^7.0",
-        "php-http/httplug"                  : "^1.0",
+        "php-http/httplug"                  : "^1.0 || ^2",
         "php-http/message-factory"          : "^1.0",
         "php-http/discovery"                : "^1.0",
         "php-http/multipart-stream-builder" : "^1.0",


### PR DESCRIPTION
Version 2 has no BC break for consumers of the interface, only for implementers (due to adding the return types to be compatible with PSR-18).