### PR TITLE
Update Postmark.php

### DIFF
--- a/lib/Mailer/Postmark.php
+++ b/lib/Mailer/Postmark.php
@@ -24,7 +24,7 @@ class Postmark extends Mailer
      */
     protected function getEndpoint()
     {
-        return 'http://api.postmarkapp.com/email';
+        return 'https://api.postmarkapp.com/email';
     }
 
     /**

--- a/tests/Stampie/Tests/Mailer/PostmarkTest.php
+++ b/tests/Stampie/Tests/Mailer/PostmarkTest.php
@@ -45,7 +45,7 @@ class PostmarkTest extends TestCase
 
                 return
                     $request->getMethod() === 'POST'
-                    && (string) $request->getUri() === 'http://api.postmarkapp.com/email'
+                    && (string) $request->getUri() === 'https://api.postmarkapp.com/email'
                     && $request->getHeaderLine('Content-Type') === 'application/json'
                     && $request->getHeaderLine('Accept') === 'application/json'
                     && $request->getHeaderLine('X-Postmark-Server-Token') === self::SERVER_TOKEN


### PR DESCRIPTION
updated endpoint.

Postmark will not accept mails coming through non secure endpoint starting from April 13, 2021.