### PR TITLE
Bump the min supported PHP version to 7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4' ]
+                php: [ '7.2', '7.3', '7.4' ]
                 min_stability: [ '' ]
                 name_suffix: [ '' ]
                 composer_flags: [ '' ]

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ The change log describes what been "Added", "Removed", "Changed" or "Fixed" betw
 
 ## Unreleased
 
+### Removed
+
+- Removed support for PHP <7.2
+
 ## 1.0.1
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         }
     },
     "require" : {
-        "php"                               : "^5.5 || ^7.0",
+        "php"                               : "^7.2",
         "php-http/httplug"                  : "^1.0 || ^2",
         "php-http/message-factory"          : "^1.0",
         "php-http/discovery"                : "^1.0",
@@ -38,7 +38,7 @@
         "php-http/client-implementation"    : "^1.0"
     },
     "require-dev" : {
-        "phpunit/phpunit" : "^4.8.36 || ^5.7.27 || ^6.5.14",
+        "phpunit/phpunit" : "^6.5.14",
         "php-http/message" : "^1.0",
         "guzzlehttp/psr7" : "^1.3",
         "php-http/mock-client" : "^1.0"
@@ -54,7 +54,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.0.x-dev"
+            "dev-main": "1.x-dev"
         }
     }
 }


### PR DESCRIPTION
Supporting PHP 5.5 requires using PHPUnit 4.8 in the testsuite. This becomes quite hard to do when needing to use PHPUnit 8+ to support PHP 8.
This drops all PHP versions that are not supported by PHPUnit 8.
the [packagist install stats for the bundle](https://packagist.org/packages/stampie/stampie-bundle/php-stats) also show PHP 7.2 being used but not older versions.