### PR TITLE
Use PSR-18 and PSR-17 directly instead of HTTPlug

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,19 @@ The change log describes what been "Added", "Removed", "Changed" or "Fixed" betw
 
 ## Unreleased
 
+### Added
+
+- Added support for using any PSR-18 client
+- Added support for providing PSR-17 factories in the mailer
+
+### Removed
+
+- Removed support for HTTPlug 1 (HTTPlug 2 is still supported as it extends PSR-18).
+
+### Deprecated
+
+- Deprecated `Stampie\Mailer::setMessageFactory` in favor of setting a PSR-17 RequestFactory
+
 ## 1.1.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ $mailer->send(new Message('reciever@domain.tld'));
 ```
 
 This simple example shows a few different things about how Stampie works under the hood and is developed. Because others
-are **so much** better than us to do HTTP communication, Stampie uses the [HTTPlug](https://httplug.io/) abstraction so
+are **so much** better than us to do HTTP communication, Stampie uses the [PSR-18](https://www.php-fig.org/psr/psr-18/) abstraction so
 you are free to choose between any library like [Buzz](https://github.com/kriswallsmith/Buzz) or [Guzzle](https://docs.guzzlephp.org).
-See the full list here: https://packagist.org/providers/php-http/client-implementation
+See the full list here: https://packagist.org/providers/psr/http-client-implementation
 
 Every mailer takes a `$serverToken` as the second argument in their constructor. This is what is used for authentication.
 In the Postmark mailer this is a hash but in SendGrid it is a `username:password` pattern that is split into two pieces
@@ -48,29 +48,28 @@ and send as arguments. A mailer is responsible for formatting the request needed
 A `Message` or `MessageInterface` is a simple storage class that holds information about the message sent to an API such 
 as the email address this is from and who should receive it together with html and text bodies.
 
-Last there is an Interface for every type of class or abstract implementation that should be used when adding new Mailer's 
+Last there is an interface for every type of class or abstract implementation that should be used when adding new Mailer's
 or Adapter's.
 
 ## Installation
 
 Stampie is not hard coupled to Guzzle or any other library that sends HTTP messages. It uses an abstraction 
-called HTTPlug. This will give you the flexibility to choose what PSR-7 implementation and HTTP client to use. 
+called PSR-18. This will give you the flexibility to choose what PSR-7 implementation and HTTP client to use.
 
 If you just want to get started quickly you should run the following command: 
 
 ```bash
-composer require stampie/stampie php-http/curl-client php-http/message guzzlehttp/psr7
+composer require stampie/stampie php-http/curl-client nyholm/psr7
 ```
 
 ### Why requiring so many packages?
 
-Stampie has a dependency on the virtual package [php-http/client-implementation](https://packagist.org/providers/php-http/client-implementation) 
+Stampie has a dependency on the virtual package [psr/http-client-implementation](https://packagist.org/providers/psr/http-client-implementation) 
 which requires to you install **an** adapter, but we do not care which one. That is an implementation detail in your application. 
-We also need **a** PSR-7 implementation and **a** message factory. 
+We also need **a** [PSR-17 implementation](https://packagist.org/providers/psr/http-factory-implementation).
 
 You do not have to use the `php-http/curl-client` if you do not want to. You may use the `php-http/guzzle6-adapter` or any
-other library in [this list](https://packagist.org/providers/php-http/client-implementation). 
-Read more about the virtual packages, why this is a good idea and about the flexibility it brings at the [HTTPlug docs](https://docs.php-http.org/en/latest/httplug/users.html).
+other library in [this list](https://packagist.org/providers/psr/http-client-implementation).
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -30,21 +30,23 @@
         }
     },
     "require" : {
-        "php"                               : "^7.2 || ^8.0",
-        "php-http/httplug"                  : "^1.0 || ^2",
-        "php-http/message-factory"          : "^1.0",
-        "php-http/discovery"                : "^1.0",
-        "php-http/multipart-stream-builder" : "^1.0",
-        "php-http/client-implementation"    : "^1.0"
+        "php": "^7.2 || ^8.0",
+        "php-http/discovery": "^1.8",
+        "php-http/multipart-stream-builder": "^1.1",
+        "psr/http-client": "^1.0.1",
+        "psr/http-client-implementation": "^1.0",
+        "psr/http-factory": "^1.0",
+        "psr/http-factory-implementation": "^1.0",
+        "symfony/deprecation-contracts": "^2.4 || ^3.0"
     },
     "require-dev" : {
         "ext-json": "*",
-        "phpunit/phpunit" : "^8.5.20 || ^9.5.9",
-        "php-http/message" : "^1.0",
-        "guzzlehttp/psr7" : "^1.3",
-        "php-http/mock-client" : "^1.0"
+        "guzzlehttp/psr7": "^2.0",
+        "phpunit/phpunit": "^8.5.20 || ^9.5.9",
+        "php-http/mock-client": "^1.0"
     },
     "conflict": {
+        "php-http/httplug": "<2",
         "sebastian/comparator": "<1.2.4"
     },
     "replace": {

--- a/tests/Stampie/Tests/MailerTest.php
+++ b/tests/Stampie/Tests/MailerTest.php
@@ -89,7 +89,8 @@ class MailerTest extends TestCase
 
         $mailer
             ->expects($this->once())
-            ->method('format');
+            ->method('format')
+            ->willReturn('');
 
         $mailer
             ->expects($this->once())
@@ -138,6 +139,9 @@ class MailerTest extends TestCase
         $mailer->expects($this->any())
             ->method('getEndpoint')
             ->willReturn('https://example.com/fake-endpoint');
+
+        $mailer->method('format')
+            ->willReturn('');
 
         return $mailer;
     }


### PR DESCRIPTION
Projects using HTTPlug 2 will have an easy update, as HTTPlug 2 implements PSR-18 directly. For the factories, the mailer keeps a BC layer supporting the HTTPlug factories rather than the PSR-17 one.
Projects using HTTPlug 1 won't be able to update Stampie until they migrate (which is generally easy as the BC breaks between 1 and 2 are only for implementors of the interface, not for consumers).