### PR TITLE
Make the email mandatory in the Identity class

### DIFF
--- a/lib/Identity.php
+++ b/lib/Identity.php
@@ -8,7 +8,7 @@ namespace Stampie;
 class Identity implements IdentityInterface
 {
     /**
-     * @var string|null
+     * @var string
      */
     private $email;
 
@@ -18,10 +18,10 @@ class Identity implements IdentityInterface
     private $name;
 
     /**
-     * @param string|null $email
+     * @param string      $email
      * @param string|null $name
      */
-    public function __construct($email = null, $name = null)
+    public function __construct(string $email, $name = null)
     {
         $this->email = $email;
         $this->name = $name;

--- a/tests/Stampie/Tests/Mailer/SparkPostTest.php
+++ b/tests/Stampie/Tests/Mailer/SparkPostTest.php
@@ -202,18 +202,18 @@ class SparkPostTest extends TestCase
     public function testSendWithAttachments()
     {
         $message = $this->getAttachmentsMessageMock(
-            $from = null,
-            $to = null,
-            $subject = null,
-            $html = null,
-            $text = null,
-            $headers = [],
+            'bob@example.com',
+            'alice@example.com',
+            'Stampie is awesome',
+            null,
+            null,
+            [],
             array_merge(
-                $attachments = [
+                [
                     $this->getAttachmentMock('paper.txt', 'paper.txt', 'text/plain', null),
                     $this->getAttachmentMock('apple.jpg', 'apple.jpg', 'image/jpeg', null),
                 ],
-                $images = [
+                [
                     $this->getAttachmentMock('orange.jpg', 'orange.jpg', 'image/jpeg', 'orange'),
                 ]
             )


### PR DESCRIPTION
The IdentityInterface does not allow not having an email, so the class was not fully respecting the interface.