### PR TITLE
Allow having no text or no html content in messages

### DIFF
--- a/lib/Message.php
+++ b/lib/Message.php
@@ -16,12 +16,12 @@ abstract class Message implements MessageInterface
     protected $to;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $html;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $text;
 
@@ -44,7 +44,7 @@ abstract class Message implements MessageInterface
     }
 
     /**
-     * @param string $html
+     * @param string|null $html
      *
      * @return void
      */

--- a/lib/MessageInterface.php
+++ b/lib/MessageInterface.php
@@ -46,12 +46,12 @@ interface MessageInterface
     public function getHeaders();
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getHtml();
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getText();
 }


### PR DESCRIPTION
All mailers actually handle null properly already, but the interface was not documenting it.