### PR TITLE
Bump the min PHP version to 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,15 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ '7.2', '7.3', '7.4', '8.0' ]
+                php: [ '7.4', '8.0' ]
                 min_stability: [ '' ]
                 name_suffix: [ '' ]
                 composer_flags: [ '' ]
                 include:
-                    - php: '7.4'
+                    - php: '8.0'
                       min_stability: 'dev'
                       name_suffix: ' (dev deps)'
-                    - php: '7.2'
+                    - php: '7.4'
                       min_stability: ''
                       name_suffix: ' (lowest deps)'
                       composer_flags: '--prefer-lowest'

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         }
     },
     "require" : {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "php-http/discovery": "^1.8",
         "php-http/multipart-stream-builder": "^1.1",
         "psr/http-client": "^1.0.1",
@@ -42,8 +42,8 @@
     "require-dev" : {
         "ext-json": "*",
         "guzzlehttp/psr7": "^2.0",
-        "phpunit/phpunit": "^8.5.20 || ^9.5.9",
-        "php-http/mock-client": "^1.0"
+        "php-http/mock-client": "^1.0",
+        "phpunit/phpunit": "^9.5.20"
     },
     "conflict": {
         "php-http/httplug": "<2",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
-<phpunit colors="true" bootstrap="vendor/autoload.php" >
-
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory>./lib</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="Stampie Test Suite">
             <directory>./tests/Stampie/Tests</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./lib</directory>
-        </whitelist>
-    </filter>
-
 </phpunit>


### PR DESCRIPTION
This is based on actual usage stats on Packagist (the few usages on PHP 7.2 and 7.3 yesterday were caused by stampie/extra CI builds AFAICT)